### PR TITLE
Windows npm Scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "install": "(cd frontend && npm install) && (cd backend && npm install)",
     "install-windows": "(cd frontend && npm install) && (cd ../backend && npm install)",
     "start": "concurrently \"cd frontend && PORT=3000 npm run start\" \"cd backend && PORT=3001 npm run start\"",
+    "start-windows": "concurrently \"cd frontend && SET PORT=3000 && npm run start\" \"cd backend && SET PORT=3001 && npm run start\"",
     "test": "echo \"Error: no test specified\" && exit 1",
     "start:prod": "cd backend && npm run start:prod"
   },


### PR DESCRIPTION
Added two extra npm scripts
- "install-windows"
- "start-windows"

For Windows Users to build local:
- npm install (to install root folder package dependencies, bit dodge may look into this)
- npm run-script install-windows
- npm run-script start-windows