### PR TITLE
Expand full URL path in Swagger API docs

### DIFF
--- a/apps/api/src/routes/authRouter.ts
+++ b/apps/api/src/routes/authRouter.ts
@@ -5,7 +5,7 @@ const router = Router();
 
 /**
  * @swagger
- * /create-user:
+ * /api/auth/create-user:
  *   post:
  *     description:
  *       Create a new user.
@@ -38,7 +38,7 @@ const router = Router();
  *       404:
  *         description: Unknown user.
  *     tags:
- *       - /api/auth
+ *       - Auth
  */
 // FIXME: authenticate that the request is coming from the Auth0 rule
 router.post('/create-user', createUser);

--- a/apps/api/src/routes/portfolioRouter.ts
+++ b/apps/api/src/routes/portfolioRouter.ts
@@ -99,7 +99,7 @@ router.all('/*', (req, res, next) => {
 
 /**
  * @swagger
- * /{username}/profile:
+ * /api/portfolio/{username}/profile:
  *   get:
  *     description: View user profile information.
  *     parameters:
@@ -114,13 +114,13 @@ router.all('/*', (req, res, next) => {
  *       404:
  *         description: Unknown user.
  *     tags:
- *       - /api/portfolio
+ *       - Portfolio
  */
 router.get('/:username/profile', viewProfile);
 
 /**
  * @swagger
- * /profile:
+ * /api/portfolio/profile:
  *   put:
  *     description: Edit a user's profile.
  *     parameters:
@@ -131,13 +131,13 @@ router.get('/:username/profile', viewProfile);
  *       400:
  *         description: Malformed input.
  *     tags:
- *       - /api/portfolio
+ *       - Portfolio
  */
 router.put('/profile', editProfile);
 
 /**
  * @swagger
- * /{username}/all:
+ * /api/portfolio/{username}/all:
  *   get:
  *     description: Get all portfolio items for a user.
  *     parameters:
@@ -154,13 +154,13 @@ router.put('/profile', editProfile);
  *       404:
  *         description: Unknown user.
  *     tags:
- *       - /api/portfolio
+ *       - Portfolio
  */
 router.get('/:username/all', viewAllItems);
 
 /**
  * @swagger
- * /create:
+ * /api/portfolio/create:
  *   post:
  *     description: Create a portfolio item.
  *     parameters:
@@ -173,13 +173,13 @@ router.get('/:username/all', viewAllItems);
  *       400:
  *         description: Malformed input.
  *     tags:
- *       - /api/portfolio
+ *       - Portfolio
  */
 router.post('/create', createItem);
 
 /**
  * @swagger
- * /{portfolioItemId}:
+ * /api/portfolio/{portfolioItemId}:
  *   get:
  *     description: Get an individual portfolio item.
  *     parameters:
@@ -194,7 +194,7 @@ router.post('/create', createItem);
  *       404:
  *         description: Unknown portfolio item.
  *     tags:
- *       - /api/portfolio
+ *       - Portfolio
  *   put:
  *     description: Edit a portfolio item.
  *     parameters:
@@ -210,7 +210,7 @@ router.post('/create', createItem);
  *       401:
  *         description: Portfolio item belongs to another user.
  *     tags:
- *       - /api/portfolio
+ *       - Portfolio
  *   delete:
  *     description: Delete a portfolio item.
  *     parameters:
@@ -223,7 +223,7 @@ router.post('/create', createItem);
  *       401:
  *         description: Portfolio item belongs to another user.
  *     tags:
- *       - /api/portfolio
+ *       - Portfolio
  */
 router
   .route('/:portfolioItemId')


### PR DESCRIPTION
A very small change: using the full path for each endpoint in the Swagger docs. This is needed to make the 'Try it out' feature work (where you can enter the parameters and have it perform the request for you).