### PR TITLE
Configure lint-staged to actually lint on pre-commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     }
   },
   "lint-staged": {
-    "apps/**/*.{js}*.{js,jsx,ts,tsx,json,css}": [
+    "apps/**/*.{js,jsx,ts,tsx,json,css}": [
       "prettier --write",
       "eslint --fix"
     ]


### PR DESCRIPTION
Makes pre-commit hook run for 8.7s on my machine

Wait, I actually don't like this.

8.7s is really shitty.

From my testing of `npx eslint 'singularfilehere'` it's just simply really slow.

Running it manually is better imo, I'll just install the package in my vscode as I have also done with prettier.

