### PR TITLE
Properly document bearer auth token in Swagger endpoints

### DIFF
--- a/apps/api/src/controller/portfolioController.test.ts
+++ b/apps/api/src/controller/portfolioController.test.ts
@@ -17,7 +17,6 @@ import {
   viewProfile,
   viewProfileByJwt,
 } from './portfolioController';
-import { extraEslintDependencies } from '@nrwl/react';
 
 const username = 'test';
 const auth0Id = 'some_id';

--- a/apps/api/src/routes/authRouter.ts
+++ b/apps/api/src/routes/authRouter.ts
@@ -9,7 +9,6 @@ const router = Router();
  *   post:
  *     description:
  *       Create a new user.
- *       Should only be called from the Auth0 post-registration rule to handle a newly-registered user.
  *     parameters:
  *       - name: userInfo
  *         in: body

--- a/apps/api/src/routes/portfolioRouter.ts
+++ b/apps/api/src/routes/portfolioRouter.ts
@@ -106,6 +106,11 @@ import {
  *       type: string
  *       schema:
  *         enum: [projects, blog]
+ *   securitySchemas:
+ *     bearerAuth:
+ *       type: http
+ *       scheme: bearer
+ *       bearerFormat: JWT
  */
 
 const router = Router();
@@ -159,6 +164,8 @@ router.get('/:username/profile', viewProfile);
  *         description: Malformed input.
  *     tags:
  *       - Portfolio
+ *     security:
+ *       - bearerAuth: []
  *   put:
  *     description: Edit a user's profile.
  *     parameters:
@@ -170,6 +177,8 @@ router.get('/:username/profile', viewProfile);
  *         description: Malformed input.
  *     tags:
  *       - Portfolio
+ *     security:
+ *       - bearerAuth: []
  */
 router.route('/profile').get(checkJwt, viewProfileByJwt).put(editProfile);
 
@@ -219,6 +228,8 @@ router.get('/:username/all', viewAllPublicItems);
  *         description: Malformed input.
  *     tags:
  *       - Portfolio
+ *     security:
+ *       - bearerAuth: []
  */
 router.get('/all', checkJwt, viewAllItemsByJwt);
 
@@ -238,6 +249,8 @@ router.get('/all', checkJwt, viewAllItemsByJwt);
  *         description: Malformed input.
  *     tags:
  *       - Portfolio
+ *     security:
+ *       - bearerAuth: []
  */
 router.post('/create', createItem);
 
@@ -275,6 +288,8 @@ router.post('/create', createItem);
  *         description: Portfolio item belongs to another user.
  *     tags:
  *       - Portfolio
+ *     security:
+ *       - bearerAuth: []
  *   delete:
  *     description: Delete a portfolio item.
  *     parameters:
@@ -288,6 +303,8 @@ router.post('/create', createItem);
  *         description: Portfolio item belongs to another user.
  *     tags:
  *       - Portfolio
+ *     security:
+ *       - bearerAuth: []
  */
 router
   .route('/:portfolioItemId')


### PR DESCRIPTION
- [X] Have you updated the trello? https://trello.com/b/UnFRcMVJ

The bearer token we're using for auth is now properly present in the Swagger documentation. Swagger UI doesn't actually render the full security information (it just shows a "lock" icon next to the endpoints which require authentication), but I think it's good enough for our purposes.
