### PR TITLE
Fix card deletion bug

### DIFF
--- a/apps/client/src/app/projects/ItemList.tsx
+++ b/apps/client/src/app/projects/ItemList.tsx
@@ -42,8 +42,8 @@ const ItemList = (props: ItemList) => {
     loadItems();
   }, [loadItems]);
 
-  const itemComponents = items.map((item, index) => (
-    <ProjectItem key={index} onUpdate={loadItems} itemInfo={item} />
+  const itemComponents = items.map((item) => (
+    <ProjectItem key={item._id} onUpdate={loadItems} itemInfo={item} />
   ));
 
   return (


### PR DESCRIPTION
Fixes a bug where deleting a project item causes wrong editors to be opened. 

Switch to using the unique id as a key (https://medium.com/@robinpokorny/index-as-a-key-is-an-anti-pattern-e0349aece318). Also works with #119.

- [x] Have you updated the trello? https://trello.com/b/UnFRcMVJ
