### PR TITLE
Add spacing to avoid hiding add buttons on mobile

### DIFF
--- a/apps/client/src/app/projects/ItemList.tsx
+++ b/apps/client/src/app/projects/ItemList.tsx
@@ -47,7 +47,7 @@ const ItemList = (props: ItemList) => {
   ));
 
   return (
-    <Container className="pt-5">
+    <Container className="pt-5 mb-5 pb-5">
       <Loader loaded={loaded}>
         <Row>{itemComponents} </Row>
       </Loader>


### PR DESCRIPTION
Add blog and add project button would be hidden on mobile. This fixes that 


- [X] Have you updated the trello? https://trello.com/b/UnFRcMVJ